### PR TITLE
add jessie support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,7 @@ galaxy_info:
     - name: debian
       versions:
         - wheezy
+        - jessie
     - name: ubuntu
       versions:
         - trusty

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -7,9 +7,9 @@ playbook:
   roles:
   - role: "@ROLE_NAME@"
   tasks:
-  - name: "Check that node v0.12.4 is installed"
+  - name: "Check that the node version is installed"
     nvm: >
-      version=v0.12.4
+      version={{ node_version }}
       nvm_dir=/opt/nvm
       state=present
     register: node_installation


### PR DESCRIPTION
This PR adds jessie and replaces the hard coded node version with the `node_version` variable in the test.
