### PR TITLE
bump default node_version to v4.2.3 and nvm_version to v0.29.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
-node_version: "v0.12.4"
-nvm_version: "v0.25.4"
+node_version: "v4.2.3"
+nvm_version: "v0.29.0"
 
 nvm_dir: /opt/nvm
 node_dir: "{{ nvm_dir }}/{{ node_version }}/bin"


### PR DESCRIPTION
Bump up the node version to the latest v0.12 version.
Bump up the nvm version to v0.29.0 for better [node 4.x support](https://github.com/creationix/nvm/releases/tag/v0.27.0).
