### PR TITLE
Fix/disable spinner nodejs5

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 node_version: "v4.2.3"
-nvm_version: "v0.29.0"
+nvm_version: "v0.31.0"
 
 nvm_dir: /opt/nvm
 node_dir: "{{ nvm_dir }}/{{ node_version }}/bin"

--- a/tasks/node.yml
+++ b/tasks/node.yml
@@ -1,4 +1,23 @@
 # Installs node
+
+# Here, we ensure the spinner is disabled by default before loading nvm.sh, because loading nvm.sh with nodejs v5
+# will load invisible characters which breaks output for ansible to detect the correct ansible tmp directories,
+# therefore breaking provisioning.
+- name: "Ensure the npm spinner is disabled before loading nvm.sh"
+  sudo: false
+  lineinfile: >
+    create=yes
+    dest=~/.npmrc
+    state=present
+    regexp="^{{ item.variable }}="
+    line="{{ item.variable }}={{ item.value}}"
+  with_items:
+    - { variable: "spin", value: "false" }
+    - { variable: "progress", value: "false" }
+  tags:
+    - nodejs
+    - nvm
+
 - name: "Ensure the latest version of node is installed and ensure it's defined as the default"
   nvm: >
     version={{ node_version }}
@@ -12,8 +31,9 @@
 - name: "Disable the npm spinner"
   shell: |
     executable=/bin/bash
-    source {{ nvm_dir }}/nvm.sh && \
-    npm config --global set spin false
+    source {{ nvm_dir }}/nvm.sh >/dev/null && \
+    npm config --global set spin false && \
+    npm config --global set progress false
   tags:
     - nodejs
     - nvm


### PR DESCRIPTION
This PR sets .npmrc with the following to turn off the spinner and progress bar that breaks provisioning:

```
spin=false
progress=false
```

Fixes the `[Errno 2] No such file or directory` error when provisioning this role. For example:

```
/home/vagrant/.ansible/tmp/ansible-tmp-1456976153.0-235851347044830/setup': [Errno 2] No such file or directory
```

```
/home/vagrant/.ansible/tmp/ansible-tmp-1456976379.94-250787847233093/command': [Errno 2] No such file or directory
```
