### PR TITLE
centos: ensure gcc-c++ is installed

### DIFF
--- a/tasks/centos.yml
+++ b/tasks/centos.yml
@@ -4,6 +4,7 @@
     state=present
     enablerepo=epel
   with_items:
+    - gcc-c++
     - make
     - man
     - git


### PR DESCRIPTION
Ensures `gcc-c++` is installed for CentOS 7.
