### PR TITLE
Allow to install nvm as non-root user

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Configuration
 * `node_version`: Version of node.js to install. Default: `v0.12.4`.
 * `npm_version`: Version of NPM to install.
   Default: Use the version shipped with node.js.
+* `nvm_system_wide_install`: When set to `false`, only the current user will have its `.bashrc` update to laod `nvm`.
+  By default, all the users will load `nvm` when starting a new shell.
 
 See also
 ---------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,7 @@
-node_version: "v4.2.3"
-nvm_version: "v0.31.0"
+node_version: "v6.10.3"
+nvm_version: "v0.33.2"
 
 nvm_dir: /opt/nvm
 node_dir: "{{ nvm_dir }}/{{ node_version }}/bin"
+
+nvm_system_wide_install: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,15 +1,23 @@
 # Tasks for nodejs application
 
 - include: centos.yml
+  become: yes
+  become_user: root
   when: ansible_distribution == 'CentOS'
 
 - include: amazon.yml
+  become: yes
+  become_user: root
   when: ansible_distribution == 'Amazon'
 
 - include: debian.yml
+  become: yes
+  become_user: root
   when: ansible_distribution == 'Debian'
 
 - include: ubuntu.yml
+  become: yes
+  become_user: root
   when: ansible_distribution == 'Ubuntu'
 
 - include: nvm.yml

--- a/tasks/nvm.yml
+++ b/tasks/nvm.yml
@@ -15,6 +15,7 @@
     mode=0644
     owner=root
     group=root
+  when: nvm_system_wide_install|bool
   tags:
     - nodejs
     - nvm
@@ -27,6 +28,18 @@
     dest=/etc/profile.d/01_nvm.sh
     owner=root
     group=root
+  when: nvm_system_wide_install|bool
+  tags:
+    - nodejs
+    - nvm
+    - files
+
+- name: "Source nvm in ~/.bashrc"
+  lineinfile: >
+    dest=~/.bashrc
+    line=". {{ nvm_dir }}/nvm.sh"
+    create=yes
+  when: not nvm_system_wide_install|bool
   tags:
     - nodejs
     - nvm


### PR DESCRIPTION
Usage example:
```yaml
- role: AerisCloud.nodejs
  become: yes
  become_user: deploy
  nvm_dir: /home/deploy/.nvm
  nvm_system_wide_install: false
  tags: ['nodejs']
```