### PR TITLE
Python 3 compatibility

### DIFF
--- a/library/nvm.py
+++ b/library/nvm.py
@@ -31,8 +31,8 @@ def is_installed(version, nvm_dir):
     returncode, output, _ = nvm('ls', nvm_dir=nvm_dir)
     if returncode == 3:
         return False
-    for line in output.split('\n'):
-        if line and version in line:
+    for line in output.split(b'\n'):
+        if line and version.encode() in line:
             return True
     return False
 
@@ -65,7 +65,7 @@ def main():
             changed = True
         if default_alias:
             _, output, _ = nvm('alias', 'default', nvm_dir=nvm_dir)
-            if version not in output:
+            if version.encode() not in output:
                 returncode, _, stderr = nvm('alias', 'default', version,
                                          nvm_dir=nvm_dir)
                 if returncode != 0:


### PR DESCRIPTION
I'm using Python 3 and had to fix the following error:
```
Traceback (most recent call last):
  File \"/tmp/ansible_9gmh04d2/ansible_module_nvm.py\", line 95, in <module>
    main()
  File \"/tmp/ansible_9gmh04d2/ansible_module_nvm.py\", line 68, in main
    if version not in output:
TypeError: a bytes-like object is required, not 'str'
```

@tokyowizard Could you check it's still working for you with Python 2?